### PR TITLE
Avoid outputting huge buffer on vint error

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@ export class Tools {
   static readVint(buffer: Buffer | Uint8Array, start: number = 0): {length: number, value: number} {
     const length = 8 - Math.floor(Math.log2(buffer[start]));
     if (length > 8) {
+      if (length === Infinity) throw new Error(`Unrepresentable length: ${length}`);
       const number = Tools.readHexString(buffer, start, start + length);
       throw new Error(`Unrepresentable length: ${length} ${number}`);
     }


### PR DESCRIPTION
If the input for `log2` is a 0, `length` will be `Infinity` and can output a huge error message that can crash some setups.
This can happen with corrupt files etc.

Maybe the if condition below was supposed to catch this? However, I actually prefer to throw an error in this case.

